### PR TITLE
Velocity ramping

### DIFF
--- a/docs/api/guide.rst
+++ b/docs/api/guide.rst
@@ -1141,6 +1141,31 @@ Example
 
     >>>tmx.set_watchdog(0)
 
+set_vel_increment
+************
+
+| **endpoint**: ``0x2B``
+| **type**: Write-only
+
+Sets the maxiumum increment by which the velocity can change each control loop, making it ramp between velocities to reduce voltage spikes. Default of 50.
+
+Arguments
+---------
+
+===============   ===================  =========  =========== ================
+Member            Description          Data Type  Data Offset Default Unit
+---------------   -------------------  ---------  ----------- ----------------
+``increment``     Velocity increment   float32    0           ticks
+===============   ===================  =========  =========== ================
+
+Example
+-------
+
+.. code-block:: python
+
+    >>>tmx.set_vel_increment(100)
+
+
 Error Codes
 ###########
 

--- a/docs/api/guide.rst
+++ b/docs/api/guide.rst
@@ -1147,7 +1147,7 @@ set_vel_increment
 | **endpoint**: ``0x2B``
 | **type**: Write-only
 
-Sets the maxiumum increment by which the velocity can change each control loop, making it ramp between velocities to reduce voltage spikes. Default of 50.
+Sets the maxiumum increment by which the velocity can change each control loop, making it ramp between velocities to reduce voltage spikes. Default of 100. Setting this to 0 disables velocity ramping.
 
 Arguments
 ---------

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -43,6 +43,7 @@ BASEFLAGS += -mfloat-abi=hard
 BASEFLAGS += -mfpu=fpv4-sp-d16
 BASEFLAGS += -ffunction-sections # generate a separate ELF section for each function in the source file
 BASEFLAGS += -fdata-sections # generate a separate ELF section for each data item in the source file
+BASEFLAGS += -fno-tree-loop-distribute-patterns # disable replacing with calls to builting functions
 BASEFLAGS += -Wall
 BASEFLAGS += -Wlogical-op
 BASEFLAGS += -Waggregate-return
@@ -99,8 +100,8 @@ OBJECTS := $(addprefix $(BUILDDIR)/,$(CSOURCES:%.c=%.o)) $(addprefix $(BUILDDIR)
 all: release
 
 # Debug target
-debug: CFLAGS += -DDEBUG -g2 -O1
-debug: CPPFLAGS += -DDEBUG -g2 -O1
+debug: CFLAGS += -DDEBUG -g1 -O1
+debug: CPPFLAGS += -DDEBUG -g1 -O1
 debug: LDFLAGS += -O1
 debug: OBJECTS += $(BUILDDIR)/bootloader.o
 debug: binary

--- a/firmware/src/can/can_endpoints.c
+++ b/firmware/src/can/can_endpoints.c
@@ -83,7 +83,6 @@ void CANEP_InitEndpointMap(void)
     CANEP_AddEndpoint(&CAN_GetHallSectorMap, 0x029);
     CANEP_AddEndpoint(&CAN_SetWatchdog, 0x02A);
     CANEP_AddEndpoint(&CAN_GetSetPosVelIncrement, 0x02B);
-    // 0x02B AVAIL 
     // 0x02C AVAIL
     // 0x02D AVAIL
     // 0x02E AVAIL
@@ -632,10 +631,10 @@ uint8_t CAN_GetSetPosVelIncrement(uint8_t buffer[], uint8_t *buffer_len, bool rt
 {
     float inc;
     memcpy(&inc, &buffer[0], sizeof(float));
-    
-    Controller_SetVelIncrement(inc);
-    *buffer_len = sizeof(float);
-    inc = Controller_GetVelIncrement();
-    memcpy(&buffer[0], &inc, sizeof(float));
-    return CANRP_ReadWrite;
+    if (inc > 0)
+    {
+        Controller_SetVelIncrement(inc);
+        return CANRP_Write;
+    }
+    return CANRP_NoAction;
 }

--- a/firmware/src/can/can_endpoints.c
+++ b/firmware/src/can/can_endpoints.c
@@ -82,7 +82,8 @@ void CANEP_InitEndpointMap(void)
     CANEP_AddEndpoint(&CAN_SetMotorRL, 0x028);
     CANEP_AddEndpoint(&CAN_GetHallSectorMap, 0x029);
     CANEP_AddEndpoint(&CAN_SetWatchdog, 0x02A);
-    // 0x02B AVAIL
+    CANEP_AddEndpoint(&CAN_GetSetPosVelIncrement, 0x02B);
+    // 0x02B AVAIL 
     // 0x02C AVAIL
     // 0x02D AVAIL
     // 0x02E AVAIL
@@ -625,4 +626,16 @@ uint8_t CAN_SetWatchdog(uint8_t buffer[], uint8_t *buffer_len, bool rtr)
         return CANRP_Write;
     }
     return CANRP_NoAction;
+}
+
+uint8_t CAN_GetSetPosVelIncrement(uint8_t buffer[], uint8_t *buffer_len, bool rtr)
+{
+    float inc;
+    memcpy(&inc, &buffer[0], sizeof(float));
+    
+    Controller_SetVelIncrement(inc);
+    *buffer_len = sizeof(float);
+    inc = Controller_GetVelIncrement();
+    memcpy(&buffer[0], &inc, sizeof(float));
+    return CANRP_ReadWrite;
 }

--- a/firmware/src/can/can_endpoints.c
+++ b/firmware/src/can/can_endpoints.c
@@ -631,7 +631,7 @@ uint8_t CAN_GetSetPosVelIncrement(uint8_t buffer[], uint8_t *buffer_len, bool rt
 {
     float inc;
     memcpy(&inc, &buffer[0], sizeof(float));
-    if (inc > 0)
+    if (inc >= 0)
     {
         Controller_SetVelIncrement(inc);
         return CANRP_Write;

--- a/firmware/src/can/can_endpoints.h
+++ b/firmware/src/can/can_endpoints.h
@@ -74,3 +74,4 @@ uint8_t CAN_GetSetPosVelIq(uint8_t buffer[], uint8_t *buffer_len, bool rtr);
 uint8_t CAN_GetHallSectorMap(uint8_t buffer[], uint8_t *buffer_len, bool rtr);
 
 uint8_t CAN_SetWatchdog(uint8_t buffer[], uint8_t *buffer_len, bool rtr);
+uint8_t CAN_GetSetPosVelIncrement(uint8_t buffer[], uint8_t *buffer_len, bool rtr);

--- a/firmware/src/controller/controller.c
+++ b/firmware/src/controller/controller.c
@@ -73,7 +73,7 @@ static ControllerConfig config = {
     .Id_integrator_gain = 0.0f,
     .I_k = 0.3f,
 
-    .max_vel_increment = 20.0f}; // ticks/s 
+    .vel_increment = 50.0f}; // ticks/s 
 
 void Controller_ControlLoop(void)
 {
@@ -141,7 +141,7 @@ PAC5XXX_RAMFUNC void CLControlStep(void)
     }
 
     const float vel_setpoint_delta = state.vel_setpoint_goal - state.vel_setpoint;
-    if (abs(vel_setpoint_delta) <= config.max_vel_increment)
+    if (abs(vel_setpoint_delta) <= config.vel_increment)
     {
         state.vel_setpoint = state.vel_setpoint_goal;
     }
@@ -149,11 +149,11 @@ PAC5XXX_RAMFUNC void CLControlStep(void)
     {
         if (vel_setpoint_delta < 0)
         {
-            state.vel_setpoint -= config.max_vel_increment;
+            state.vel_setpoint -= config.vel_increment;
         }
         else 
         {
-            state.vel_setpoint += config.max_vel_increment;
+            state.vel_setpoint += config.vel_increment;
         }
     }
     // The actual velocity setpoint and the one used by the velocity integrator are
@@ -471,13 +471,13 @@ void Controller_SetVelIncrement(float increment)
 {
     if (increment > 0.0f)
     {
-        config.max_vel_increment = increment;
+        config.vel_increment = increment;
     }
 }
 
 float Controller_GetVelIncrement(void)
 {
-    return config.max_vel_increment;
+    return config.vel_increment;
 }
 
 float Controller_GetIqLimit(void)

--- a/firmware/src/controller/controller.c
+++ b/firmware/src/controller/controller.c
@@ -73,7 +73,7 @@ static ControllerConfig config = {
     .Id_integrator_gain = 0.0f,
     .I_k = 0.3f,
 
-    .vel_increment = 100.0f}; // ticks/s 
+    .vel_increment = 100.0f}; // ticks/cycle
 
 void Controller_ControlLoop(void)
 {

--- a/firmware/src/controller/controller.c
+++ b/firmware/src/controller/controller.c
@@ -469,7 +469,7 @@ void Controller_SetVelLimit(float limit)
 
 void Controller_SetVelIncrement(float increment)
 {
-    if (increment > 0.0f)
+    if (increment >= 0.0f)
     {
         config.vel_increment = increment;
     }

--- a/firmware/src/controller/controller.h
+++ b/firmware/src/controller/controller.h
@@ -51,6 +51,7 @@ typedef struct
 
     float pos_setpoint;
     float vel_setpoint;
+    float vel_setpoint_goal;
     float Iq_setpoint;
 
     float vel_integrator_Iq;
@@ -76,6 +77,8 @@ typedef struct
     float Iq_integrator_gain;
     float Id_integrator_gain;
     float I_k;
+    
+    float max_vel_increment;
 } ControllerConfig;
 
 void Controller_ControlLoop(void);
@@ -117,6 +120,8 @@ float Controller_GetVelLimit(void);
 void Controller_SetVelLimit(float limit);
 float Controller_GetIqLimit(void);
 void Controller_SetIqLimit(float limit);
+float Controller_GetVelIncrement(void);
+void Controller_SetVelIncrement(float inc);
 
 void controller_set_motion_plan(MotionPlan mp);
 

--- a/firmware/src/controller/controller.h
+++ b/firmware/src/controller/controller.h
@@ -51,7 +51,7 @@ typedef struct
 
     float pos_setpoint;
     float vel_setpoint;
-    float vel_setpoint_goal;
+    float vel_ramp_setpoint;
     float Iq_setpoint;
 
     float vel_integrator_Iq;

--- a/firmware/src/controller/controller.h
+++ b/firmware/src/controller/controller.h
@@ -78,7 +78,7 @@ typedef struct
     float Id_integrator_gain;
     float I_k;
     
-    float max_vel_increment;
+    float vel_increment;
 } ControllerConfig;
 
 void Controller_ControlLoop(void);

--- a/firmware/src/motor/calibration.c
+++ b/firmware/src/motor/calibration.c
@@ -276,7 +276,7 @@ static inline void set_epos_and_wait(float angle, float I_setpoint)
 {
 	struct FloatTriplet modulation_values = {0.0f};
 	float pwm_setpoint = (I_setpoint * motor_get_phase_resistance()) / ADC_GetVBus();
-	our_clamp(&pwm_setpoint, -PWM_LIMIT, PWM_LIMIT);
+	our_clampc(&pwm_setpoint, -PWM_LIMIT, PWM_LIMIT);
 	SVM(pwm_setpoint * fast_cos(angle), pwm_setpoint * fast_sin(angle),
 		&modulation_values.A, &modulation_values.B, &modulation_values.C);
 	gate_driver_set_duty_cycle(&modulation_values);

--- a/firmware/src/utils/utils.h
+++ b/firmware/src/utils/utils.h
@@ -80,11 +80,17 @@ static inline void delay_us(uint32_t us)
     pac_delay_asm(us * 16u);
 }
 
-static inline bool our_clamp(float *d, float min, float max)
+static inline bool our_clampc(float *d, float min, float max)
 {
     const float t = *d < min ? min : *d;
     *d = t > max ? max : t;
     return (*d == min) || (*d == max);
+}
+
+static inline float our_clamp(float d, float min, float max)
+{
+    const float t = d < min ? min : d;
+    return t > max ? max : t;
 }
 
 static inline float our_floorf(float x)

--- a/studio/Python/tinymovr/iface/can_bus/endpoints.py
+++ b/studio/Python/tinymovr/iface/can_bus/endpoints.py
@@ -388,12 +388,11 @@ for velocity-limited plan moves",
     },
     "set_vel_inc":
     {
-        "description": "Set vel inc.",
+        "description": "Set velocity increment (ramp). Set to zero to disable.",
         "type": "w",
         "ep_id": 0x02B,
         "types": (DataType.FLOAT,),
-        "units": ("ticks/second",),
         "labels": ("increment",),
-        "defaults": {"increment": 50,}
+        "defaults": {"increment": 100,}
     },
 }

--- a/studio/Python/tinymovr/iface/can_bus/endpoints.py
+++ b/studio/Python/tinymovr/iface/can_bus/endpoints.py
@@ -389,11 +389,11 @@ for velocity-limited plan moves",
     "set_vel_inc":
     {
         "description": "Set vel inc.",
-        "type": "rw",
+        "type": "w",
         "ep_id": 0x02B,
         "types": (DataType.FLOAT,),
         "units": ("ticks/second",),
         "labels": ("increment",),
-        "defaults": {"increment": 100,}
+        "defaults": {"increment": 50,}
     },
 }

--- a/studio/Python/tinymovr/iface/can_bus/endpoints.py
+++ b/studio/Python/tinymovr/iface/can_bus/endpoints.py
@@ -386,4 +386,14 @@ for velocity-limited plan moves",
         "defaults": {"timeout": 3},
         "labels": ("enabled", "timeout")
     },
+    "set_vel_inc":
+    {
+        "description": "Set vel inc.",
+        "type": "rw",
+        "ep_id": 0x02B,
+        "types": (DataType.FLOAT,),
+        "units": ("ticks/second",),
+        "labels": ("increment",),
+        "defaults": {"increment": 100,}
+    },
 }


### PR DESCRIPTION
Sudden changes in velocity setpoints would lead to sudden jerks and current spikes, so a ramping function is added to make transitions a bit smoother. This allows for very quick but still smooth transitions between velocities, and can be disabled by setting the velocity increment very high.