### PR TITLE
Add release launch target

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,26 @@
                 // Update the path below as necessary
                 "serverpath": "/opt/SEGGER/JLink/JLinkGDBServer" 
             }
+        },
+        {
+            "cwd": "${workspaceRoot}",
+            "executable": "${workspaceRoot}/firmware/build/tinymovr_fw.elf",
+            "name": "Flash Tinymovr Release",
+            "request": "launch",
+            "type": "cortex-debug",
+            "servertype": "jlink",
+            "device": "PAC55XX",
+            "interface": "swd",
+            "svdFile": "${workspaceRoot}/firmware/PAC55XX.svd",
+            "preLaunchTask": "Build Project (Release)",
+            "windows": {
+                // Update the path below as necessary
+                "serverpath": "C:\\Program Files (x86)\\SEGGER\\JLink_V631b\\JLinkGDBServerCL.exe" 
+            },
+            "linux": {
+                // Update the path below as necessary
+                "serverpath": "/opt/SEGGER/JLink/JLinkGDBServer" 
+            }
         }
     ]
 }


### PR DESCRIPTION
I'm not sure of the best way to flash the release version of the code, and I couldn't find it in the documentation, so I've added a VSCode launch target for it to make it easily accessible. Do you think this is a good way to do it? It would also be worth updating the documentation with instructions on how to flash in release.