### PR TITLE
Load device.yaml in Python3.8 compatible way

### DIFF
--- a/studio/Python/tinymovr/config/config.py
+++ b/studio/Python/tinymovr/config/config.py
@@ -17,19 +17,15 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 import yaml
 import logging
-import importlib
+from importlib import resources
 import can
 
 from avlos.deserializer import deserialize
 from tinymovr.codec import DataType
 from tinymovr.channel import CANChannel
 
-dev_def = None
-
-def_path_str = str(importlib.resources.files("tinymovr").joinpath("config/device.yaml"))
-with open(def_path_str) as dev_def_raw:
-    dev_def = yaml.safe_load(dev_def_raw)
-
+dev_def_raw = resources.read_text(__package__, "device.yaml")
+dev_def = yaml.safe_load(dev_def_raw)
 
 class ProtocolVersionError(Exception):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Started playing around with the new comms layer and had to remove the usage of `importlib.resources.files` which is not available in Python =<3.8. Should still be compatible with Python3.9 (but please test!)