### PR TITLE
Process all CAN messages in buffer

### DIFF
--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -20,7 +20,7 @@
 // Firmware Version
 #define VERSION_MAJOR (0u)
 #define VERSION_MINOR (8u)
-#define VERSION_PATCH (17u)
+#define VERSION_PATCH (18u)
 
 // Required Studio version
 #define STUDIO_MIN_VERSION_MAJOR (0u)

--- a/firmware/src/scheduler/scheduler.c
+++ b/firmware/src/scheduler/scheduler.c
@@ -53,8 +53,12 @@ void WaitForControlLoopInterrupt(void)
 		if (state.can_interrupt)
 		{
 			// Handle CAN
-			state.can_interrupt = false;
 			CAN_process_interrupt();
+			// Only clear the flag if all messages in the CAN RX buffer have been processed
+			if (PAC55XX_CAN->SR.RBS == 0)
+			{
+				state.can_interrupt = false;
+			}
 		}
 		else if (state.uart_message_interrupt)
 		{

--- a/studio/Python/tinymovr/bus/insilico.py
+++ b/studio/Python/tinymovr/bus/insilico.py
@@ -179,7 +179,7 @@ class InSilico(can.BusABC):
         self.buffer = create_frame(self.node_id, 0x17, False, gen_payload)
 
     def _get_device_info(self, payload):
-        vals: Tuple = (0, 0, 8, 17, 25)
+        vals: Tuple = (0, 0, 8, 18, 25)
         gen_payload = self.codec.serialize(vals, *can_endpoints["device_info"]["types"])
         self.buffer = create_frame(self.node_id, 0x1A, False, gen_payload)
 


### PR DESCRIPTION
I've been having major issues with CAN, where an ESC would get "out of sync" and send back the previously asked for endpoint, or would become completely uncommunicative on CAN. After much debugging I realised it was due to two messages coming in close succession, which would set the state.can_interrupt flag before it had a chance to be cleared. When it came time to process the messages, CAN_process_interrupt is only called once and the flag cleared, leaving an extra message in the buffer unprocessed. This old message would then get processed the next time, and the new message would be left in the buffer, etc. Basically, we can't assume that there's only one message in the buffer when we go to process it. 
I'm still not entirely sure why it would sometimes become completely unresponsive on the bus, but from inspecting the CAN registers when this happens, it gets caught in a state where the RBS flag is set (indicating that the buffer contains unread data) but the CAN interrupt doesn't seem to trigger despite the interrupt mask being set and the interrupt being cleared.
Interestingly, I found that some ESCs were consistently more prone to the error than others - maybe some would process slower? Also, a `set_vel_setpoint` followed immediately by some other request (e.g. `Iq` or `state`) caused the error to happen much more reliably than just sending the request - no idea why but I thought I'd record it here for completeness.

I've fixed the error by only clearing the flag if the CAN RX FIFO buffer is cleared.
I noticed in the PAC55XX datasheet that the CAN receive message counter (RMC) is decremented on clearing the CAN receive interrupt flag, so message processing is expected to happen in the interrupt routine. It might be worth processing at least the message RX in the interrupt routine - what are your thoughts?