### PR TITLE
Add Time-Limited Trajectory Planner Endpoints

### DIFF
--- a/docs/protocol/reference.rst
+++ b/docs/protocol/reference.rst
@@ -708,7 +708,7 @@ ID: 58
 Type: float
 Units: tick / second
 
-The trajectory planner max acceleration.
+The max allowed acceleration of the generated trajectory.
 
 
 
@@ -720,7 +720,7 @@ ID: 59
 Type: float
 Units: tick / second ** 2
 
-The trajectory planner max deceleration.
+The max allowed deceleration of the generated trajectory.
 
 
 
@@ -732,7 +732,43 @@ ID: 60
 Type: float
 Units: tick / second
 
-The trajectory planner max cruise velocity.
+The max allowed cruise velocity of the generated trajectory.
+
+
+
+
+traj_planner.t_accel
+-------------------------------------------------------------------
+
+ID: 61
+Type: float
+Units: second
+
+In time mode, the acceleration time of the generated trajectory.
+
+
+
+
+traj_planner.t_decel
+-------------------------------------------------------------------
+
+ID: 62
+Type: float
+Units: second
+
+In time mode, the deceleration time of the generated trajectory.
+
+
+
+
+traj_planner.t_total
+-------------------------------------------------------------------
+
+ID: 63
+Type: float
+Units: second
+
+In time mode, the total time of the generated trajectory.
 
 
 
@@ -740,7 +776,7 @@ The trajectory planner max cruise velocity.
 move_to(pos_setpoint) -> void
 -------------------------------------------------------------------
 
-ID: 61
+ID: 64
 Return Type: void
 
 
@@ -750,7 +786,7 @@ Move to target position respecting velocity and acceleration limits.
 move_to_tlimit(pos_setpoint) -> void
 -------------------------------------------------------------------
 
-ID: 62
+ID: 65
 Return Type: void
 
 
@@ -760,7 +796,7 @@ Move to target position respecting time limits for each sector.
 traj_planner.errors
 -------------------------------------------------------------------
 
-ID: 63
+ID: 66
 Type: uint8
 
 
@@ -774,7 +810,7 @@ Flags:
 watchdog.enabled
 -------------------------------------------------------------------
 
-ID: 64
+ID: 67
 Type: bool
 
 
@@ -786,7 +822,7 @@ Whether the watchdog is enabled or not.
 watchdog.triggered
 -------------------------------------------------------------------
 
-ID: 65
+ID: 68
 Type: bool
 
 
@@ -798,7 +834,7 @@ Whether the watchdog has been triggered or not.
 watchdog.timeout
 -------------------------------------------------------------------
 
-ID: 66
+ID: 69
 Type: float
 Units: second
 

--- a/firmware/src/can/can.c
+++ b/firmware/src/can/can.c
@@ -131,6 +131,7 @@ void CAN_process_interrupt(void)
         uint8_t (*callback)(uint8_t buffer[], uint8_t * buffer_length, Avlos_Command cmd) = avlos_endpoints[can_ep_id];
         uint8_t can_msg_buffer[8];
         memcpy(can_msg_buffer, &rx_data, data_length);
+        data_length = 0;
         uint8_t response_type = callback(can_msg_buffer, &data_length, (uint8_t)rtr);
         if ((AVLOS_RET_READ == response_type || AVLOS_RET_CALL == response_type) && (data_length > 0))
         {

--- a/firmware/src/can/can_endpoints.c
+++ b/firmware/src/can/can_endpoints.c
@@ -18,8 +18,8 @@
 #include <src/can/can_endpoints.h>
 
 
-uint8_t (*avlos_endpoints[67])(uint8_t * buffer, uint8_t * buffer_len, Avlos_Command cmd) = {&avlos_protocol_hash, &avlos_uid, &avlos_Vbus, &avlos_Ibus, &avlos_power, &avlos_temp, &avlos_calibrated, &avlos_errors, &avlos_save_config, &avlos_erase_config, &avlos_reset, &avlos_scheduler_total, &avlos_scheduler_busy, &avlos_scheduler_errors, &avlos_controller_state, &avlos_controller_mode, &avlos_controller_warnings, &avlos_controller_errors, &avlos_controller_position_setpoint, &avlos_controller_position_p_gain, &avlos_controller_velocity_setpoint, &avlos_controller_velocity_limit, &avlos_controller_velocity_p_gain, &avlos_controller_velocity_i_gain, &avlos_controller_velocity_deadband, &avlos_controller_velocity_increment, &avlos_controller_current_Iq_setpoint, &avlos_controller_current_Id_setpoint, &avlos_controller_current_Iq_limit, &avlos_controller_current_Iq_estimate, &avlos_controller_current_bandwidth, &avlos_controller_current_Iq_p_gain, &avlos_controller_current_max_Ibus_regen, &avlos_controller_current_max_Ibrake, &avlos_controller_voltage_Vq_setpoint, &avlos_controller_calibrate, &avlos_controller_idle, &avlos_controller_position_mode, &avlos_controller_velocity_mode, &avlos_controller_current_mode, &avlos_controller_set_pos_vel_setpoints, &avlos_comms_can_rate, &avlos_comms_can_id, &avlos_motor_R, &avlos_motor_L, &avlos_motor_pole_pairs, &avlos_motor_type, &avlos_motor_offset, &avlos_motor_direction, &avlos_motor_calibrated, &avlos_motor_I_cal, &avlos_motor_errors, &avlos_encoder_position_estimate, &avlos_encoder_velocity_estimate, &avlos_encoder_type, &avlos_encoder_bandwidth, &avlos_encoder_calibrated, &avlos_encoder_errors, &avlos_traj_planner_max_accel, &avlos_traj_planner_max_decel, &avlos_traj_planner_max_vel, &avlos_traj_planner_move_to, &avlos_traj_planner_move_to_tlimit, &avlos_traj_planner_errors, &avlos_watchdog_enabled, &avlos_watchdog_triggered, &avlos_watchdog_timeout };
-uint32_t avlos_proto_hash = 3273002564;
+uint8_t (*avlos_endpoints[70])(uint8_t * buffer, uint8_t * buffer_len, Avlos_Command cmd) = {&avlos_protocol_hash, &avlos_uid, &avlos_Vbus, &avlos_Ibus, &avlos_power, &avlos_temp, &avlos_calibrated, &avlos_errors, &avlos_save_config, &avlos_erase_config, &avlos_reset, &avlos_scheduler_total, &avlos_scheduler_busy, &avlos_scheduler_errors, &avlos_controller_state, &avlos_controller_mode, &avlos_controller_warnings, &avlos_controller_errors, &avlos_controller_position_setpoint, &avlos_controller_position_p_gain, &avlos_controller_velocity_setpoint, &avlos_controller_velocity_limit, &avlos_controller_velocity_p_gain, &avlos_controller_velocity_i_gain, &avlos_controller_velocity_deadband, &avlos_controller_velocity_increment, &avlos_controller_current_Iq_setpoint, &avlos_controller_current_Id_setpoint, &avlos_controller_current_Iq_limit, &avlos_controller_current_Iq_estimate, &avlos_controller_current_bandwidth, &avlos_controller_current_Iq_p_gain, &avlos_controller_current_max_Ibus_regen, &avlos_controller_current_max_Ibrake, &avlos_controller_voltage_Vq_setpoint, &avlos_controller_calibrate, &avlos_controller_idle, &avlos_controller_position_mode, &avlos_controller_velocity_mode, &avlos_controller_current_mode, &avlos_controller_set_pos_vel_setpoints, &avlos_comms_can_rate, &avlos_comms_can_id, &avlos_motor_R, &avlos_motor_L, &avlos_motor_pole_pairs, &avlos_motor_type, &avlos_motor_offset, &avlos_motor_direction, &avlos_motor_calibrated, &avlos_motor_I_cal, &avlos_motor_errors, &avlos_encoder_position_estimate, &avlos_encoder_velocity_estimate, &avlos_encoder_type, &avlos_encoder_bandwidth, &avlos_encoder_calibrated, &avlos_encoder_errors, &avlos_traj_planner_max_accel, &avlos_traj_planner_max_decel, &avlos_traj_planner_max_vel, &avlos_traj_planner_t_accel, &avlos_traj_planner_t_decel, &avlos_traj_planner_t_total, &avlos_traj_planner_move_to, &avlos_traj_planner_move_to_tlimit, &avlos_traj_planner_errors, &avlos_watchdog_enabled, &avlos_watchdog_triggered, &avlos_watchdog_timeout };
+uint32_t avlos_proto_hash = 949626128;
 
 uint32_t _avlos_get_proto_hash(void)
 {
@@ -891,6 +891,60 @@ else if (AVLOS_CMD_WRITE == cmd) {
         float v;
         memcpy(&v, buffer, sizeof(v));
         planner_set_max_vel(v);
+        return AVLOS_RET_WRITE;
+    }
+    return AVLOS_RET_NOACTION;
+}
+
+uint8_t avlos_traj_planner_t_accel(uint8_t * buffer, uint8_t * buffer_len, Avlos_Command cmd)
+{
+if (AVLOS_CMD_READ == cmd) {
+        float v;
+        v = planner_get_deltat_accel();
+        *buffer_len = sizeof(v);
+        memcpy(buffer, &v, sizeof(v));
+        return AVLOS_RET_READ;
+    }
+else if (AVLOS_CMD_WRITE == cmd) {
+        float v;
+        memcpy(&v, buffer, sizeof(v));
+        planner_set_deltat_accel(v);
+        return AVLOS_RET_WRITE;
+    }
+    return AVLOS_RET_NOACTION;
+}
+
+uint8_t avlos_traj_planner_t_decel(uint8_t * buffer, uint8_t * buffer_len, Avlos_Command cmd)
+{
+if (AVLOS_CMD_READ == cmd) {
+        float v;
+        v = planner_get_deltat_decel();
+        *buffer_len = sizeof(v);
+        memcpy(buffer, &v, sizeof(v));
+        return AVLOS_RET_READ;
+    }
+else if (AVLOS_CMD_WRITE == cmd) {
+        float v;
+        memcpy(&v, buffer, sizeof(v));
+        planner_set_deltat_decel(v);
+        return AVLOS_RET_WRITE;
+    }
+    return AVLOS_RET_NOACTION;
+}
+
+uint8_t avlos_traj_planner_t_total(uint8_t * buffer, uint8_t * buffer_len, Avlos_Command cmd)
+{
+if (AVLOS_CMD_READ == cmd) {
+        float v;
+        v = planner_get_deltat_total();
+        *buffer_len = sizeof(v);
+        memcpy(buffer, &v, sizeof(v));
+        return AVLOS_RET_READ;
+    }
+else if (AVLOS_CMD_WRITE == cmd) {
+        float v;
+        memcpy(&v, buffer, sizeof(v));
+        planner_set_deltat_total(v);
         return AVLOS_RET_WRITE;
     }
     return AVLOS_RET_NOACTION;

--- a/firmware/src/can/can_endpoints.h
+++ b/firmware/src/can/can_endpoints.h
@@ -73,7 +73,7 @@ typedef enum
 } traj_planner_errors_flags;
 
 extern uint32_t avlos_proto_hash;
-extern uint8_t (*avlos_endpoints[67])(uint8_t * buffer, uint8_t * buffer_len, Avlos_Command cmd);
+extern uint8_t (*avlos_endpoints[70])(uint8_t * buffer, uint8_t * buffer_len, Avlos_Command cmd);
 extern uint32_t _avlos_get_proto_hash(void);
 
 /*
@@ -659,7 +659,7 @@ uint8_t avlos_encoder_errors(uint8_t * buffer, uint8_t * buffer_len, Avlos_Comma
 /*
 * avlos_traj_planner_max_accel
 *
-* The trajectory planner max acceleration.
+* The max allowed acceleration of the generated trajectory.
 *
 * @param buffer
 * @param buffer_len
@@ -669,7 +669,7 @@ uint8_t avlos_traj_planner_max_accel(uint8_t * buffer, uint8_t * buffer_len, Avl
 /*
 * avlos_traj_planner_max_decel
 *
-* The trajectory planner max deceleration.
+* The max allowed deceleration of the generated trajectory.
 *
 * @param buffer
 * @param buffer_len
@@ -679,12 +679,42 @@ uint8_t avlos_traj_planner_max_decel(uint8_t * buffer, uint8_t * buffer_len, Avl
 /*
 * avlos_traj_planner_max_vel
 *
-* The trajectory planner max cruise velocity.
+* The max allowed cruise velocity of the generated trajectory.
 *
 * @param buffer
 * @param buffer_len
 */
 uint8_t avlos_traj_planner_max_vel(uint8_t * buffer, uint8_t * buffer_len, Avlos_Command cmd);
+
+/*
+* avlos_traj_planner_t_accel
+*
+* In time mode, the acceleration time of the generated trajectory.
+*
+* @param buffer
+* @param buffer_len
+*/
+uint8_t avlos_traj_planner_t_accel(uint8_t * buffer, uint8_t * buffer_len, Avlos_Command cmd);
+
+/*
+* avlos_traj_planner_t_decel
+*
+* In time mode, the deceleration time of the generated trajectory.
+*
+* @param buffer
+* @param buffer_len
+*/
+uint8_t avlos_traj_planner_t_decel(uint8_t * buffer, uint8_t * buffer_len, Avlos_Command cmd);
+
+/*
+* avlos_traj_planner_t_total
+*
+* In time mode, the total time of the generated trajectory.
+*
+* @param buffer
+* @param buffer_len
+*/
+uint8_t avlos_traj_planner_t_total(uint8_t * buffer, uint8_t * buffer_len, Avlos_Command cmd);
 
 /*
 * avlos_traj_planner_move_to

--- a/firmware/src/controller/controller.c
+++ b/firmware/src/controller/controller.c
@@ -587,12 +587,12 @@ void controller_set_motion_plan(MotionPlan mp)
     state.t_plan = 0.0f;
 }
 
-ControllerConfig *Controller_GetConfig(void)
+ControllerConfig *controller_get_config(void)
 {
     return &config;
 }
 
-void Controller_RestoreConfig(ControllerConfig *config_)
+void controller_restore_config(ControllerConfig *config_)
 {
     config = *config_;
 }

--- a/firmware/src/controller/controller.h
+++ b/firmware/src/controller/controller.h
@@ -149,7 +149,7 @@ void controller_update_I_gains(void);
 uint8_t controller_get_warnings(void);
 uint8_t controller_get_errors(void);
 
-ControllerConfig *Controller_GetConfig(void);
-void Controller_RestoreConfig(ControllerConfig *config_);
+ControllerConfig *controller_get_config(void);
+void controller_restore_config(ControllerConfig *config_);
 
 #endif /* CONTROLLER_CONTROLLER_H_ */

--- a/firmware/src/controller/trajectory_planner.c
+++ b/firmware/src/controller/trajectory_planner.c
@@ -22,10 +22,13 @@
 #include <src/utils/utils.h>
 #include <src/controller/trajectory_planner.h>
 
-static PlannerConfig config = {
+static TrajPlannerConfig config = {
 	.max_accel = ENCODER_TICKS_FLOAT,
 	.max_decel = ENCODER_TICKS_FLOAT,
-	.max_vel = 50000.0f
+	.max_vel = 50000.0f,
+	.deltat_accel = 2.0f,
+	.deltat_decel = 2.0f,
+	.deltat_total = 5.0f
 };
 
 static PlannerState state = {0};
@@ -329,4 +332,14 @@ TM_RAMFUNC bool planner_evaluate(float t, MotionPlan *plan)
 		response = false;
 	}
 	return response;
+}
+
+TrajPlannerConfig *traj_planner_get_config(void)
+{
+    return &config;
+}
+
+void traj_planner_restore_config(TrajPlannerConfig *config_)
+{
+    config = *config_;
 }

--- a/firmware/src/controller/trajectory_planner.h
+++ b/firmware/src/controller/trajectory_planner.h
@@ -27,7 +27,7 @@ typedef struct {
     float deltat_accel;
     float deltat_total;
     float deltat_decel;
-} PlannerConfig;
+} TrajPlannerConfig;
 
 typedef struct {
 	uint8_t errors;
@@ -76,5 +76,8 @@ bool planner_set_deltat_decel(float deltat_decel);
 uint8_t planner_get_errors(void);
 
 bool planner_evaluate(float t, MotionPlan *plan);
+
+TrajPlannerConfig *traj_planner_get_config(void);
+void traj_planner_restore_config(TrajPlannerConfig *config_);
 
 #endif /* CONTROLLER_TRAJECTORY_PLANNER_H_ */

--- a/firmware/src/nvm/nvm.c
+++ b/firmware/src/nvm/nvm.c
@@ -32,8 +32,8 @@ bool nvm_save_config(void)
 	s.hall_config = *hall_get_config();
 	s.ma7xx_config = *ma7xx_get_config();
 	s.encoder_config = *encoder_get_config();
-	s.observer_config = *Observer_GetConfig();
-	s.controller_config = *Controller_GetConfig();
+	s.observer_config = *observer_get_config();
+	s.controller_config = *controller_get_config();
 	s.can_config = *CAN_get_config();
 	s.traj_planner_config = *traj_planner_get_config();
 	strlcpy(s.version, GIT_VERSION, sizeof(s.version));
@@ -64,8 +64,8 @@ bool nvm_load_config(void)
 		hall_restore_config(&s.hall_config);
 		ma7xx_restore_config(&s.ma7xx_config);
 		encoder_restore_config(&s.encoder_config);
-		Observer_RestoreConfig(&s.observer_config);
-		Controller_RestoreConfig(&s.controller_config);
+		observer_restore_config(&s.observer_config);
+		controller_restore_config(&s.controller_config);
 		CAN_restore_config(&s.can_config);
 		traj_planner_restore_config(&s.traj_planner_config);
 		loaded = true;

--- a/firmware/src/nvm/nvm.c
+++ b/firmware/src/nvm/nvm.c
@@ -35,6 +35,7 @@ bool nvm_save_config(void)
 	s.observer_config = *Observer_GetConfig();
 	s.controller_config = *Controller_GetConfig();
 	s.can_config = *CAN_get_config();
+	s.traj_planner_config = *traj_planner_get_config();
 	strlcpy(s.version, GIT_VERSION, sizeof(s.version));
 	memcpy(data, &s, sizeof(struct NVMStruct));
 	if (STATE_IDLE == controller_get_state())
@@ -66,6 +67,7 @@ bool nvm_load_config(void)
 		Observer_RestoreConfig(&s.observer_config);
 		Controller_RestoreConfig(&s.controller_config);
 		CAN_restore_config(&s.can_config);
+		traj_planner_restore_config(&s.traj_planner_config);
 		loaded = true;
 	}
 	return loaded;

--- a/firmware/src/nvm/nvm.h
+++ b/firmware/src/nvm/nvm.h
@@ -24,6 +24,7 @@
 #include <src/encoder/encoder.h>
 #include <src/observer/observer.h>
 #include <src/controller/controller.h>
+#include <src/controller/trajectory_planner.h>
 #include <src/can/can.h>
 
 #define SETTINGS_PAGE (120)
@@ -38,6 +39,7 @@ struct NVMStruct {
     ObserverConfig observer_config;
     ControllerConfig controller_config;
     CANConfig can_config;
+    TrajPlannerConfig traj_planner_config;
     char version[16];
 };
 

--- a/firmware/src/observer/observer.c
+++ b/firmware/src/observer/observer.c
@@ -138,12 +138,12 @@ TM_RAMFUNC float observer_get_vel_estimate_user_frame(void)
 	return state.vel_estimate * motor_get_user_direction();
 }
 
-ObserverConfig* Observer_GetConfig(void)
+ObserverConfig* observer_get_config(void)
 {
 	return &config;
 }
 
-void Observer_RestoreConfig(ObserverConfig* config_)
+void observer_restore_config(ObserverConfig* config_)
 {
 	config = *config_;
 }

--- a/firmware/src/observer/observer.h
+++ b/firmware/src/observer/observer.h
@@ -56,7 +56,7 @@ float observer_get_vel_estimate_user_frame(void);
 float observer_get_bw(void);
 void observer_set_bw(float bw);
 
-ObserverConfig* Observer_GetConfig(void);
-void Observer_RestoreConfig(ObserverConfig* config_);
+ObserverConfig* observer_get_config(void);
+void observer_restore_config(ObserverConfig* config_);
 
 #endif /* OBSERVER_OBSERVER_H_ */

--- a/studio/Python/tests/test_traj_planner.py
+++ b/studio/Python/tests/test_traj_planner.py
@@ -66,6 +66,28 @@ class TestTrajPlanner(TMTestCase):
         self.tm.traj_planner.move_to(self.tm.controller.position.setpoint)
         time.sleep(4)
 
+    def test_traj_planner_tlimit(self):
+        """
+        Test trajectory planner with time limits
+        """
+        self.check_state(0)
+        self.try_calibrate()
+        self.tm.controller.position_mode()
+        self.check_state(2)
+
+        time.sleep(1)
+
+        self.tm.traj_planner.max_vel = 200000
+        self.tm.traj_planner.t_accel = 1
+        self.tm.traj_planner.t_decel = 1
+        self.tm.traj_planner.t_total = 3
+
+        for _ in range(5):
+            self.tm.traj_planner.move_to_tlimit(random.randrange(-100000, 100000))
+            time.sleep(0.6)
+
+        self.tm.traj_planner.move_to_tlimit(self.tm.controller.position.setpoint)
+        time.sleep(4)
 
 if __name__ == "__main__":
     unittest.main(failfast=True)

--- a/studio/Python/tinymovr/config/device.yaml
+++ b/studio/Python/tinymovr/config/device.yaml
@@ -387,21 +387,42 @@ remote_attributes:
         meta: {export: True}
         getter_name: planner_get_max_accel
         setter_name: planner_set_max_accel
-        summary: The trajectory planner max acceleration.
+        summary: The max allowed acceleration of the generated trajectory.
       - name: max_decel
         dtype: float
         unit: ticks/second/second
         meta: {export: True}
         getter_name: planner_get_max_decel
         setter_name: planner_set_max_decel
-        summary: The trajectory planner max deceleration.
+        summary: The max allowed deceleration of the generated trajectory.
       - name: max_vel
         dtype: float
         unit: ticks/second
         meta: {export: True}
         getter_name: planner_get_max_vel
         setter_name: planner_set_max_vel
-        summary: The trajectory planner max cruise velocity.
+        summary: The max allowed cruise velocity of the generated trajectory.
+      - name: t_accel
+        dtype: float
+        unit: second
+        meta: {export: True}
+        getter_name: planner_get_deltat_accel
+        setter_name: planner_set_deltat_accel
+        summary: In time mode, the acceleration time of the generated trajectory.
+      - name: t_decel
+        dtype: float
+        unit: second
+        meta: {export: True}
+        getter_name: planner_get_deltat_decel
+        setter_name: planner_set_deltat_decel
+        summary: In time mode, the deceleration time of the generated trajectory.
+      - name: t_total
+        dtype: float
+        unit: second
+        meta: {export: True}
+        getter_name: planner_get_deltat_total
+        setter_name: planner_set_deltat_total
+        summary: In time mode, the total time of the generated trajectory.
       - name: move_to
         summary: Move to target position respecting velocity and acceleration limits.
         caller_name: planner_move_to_vlimit


### PR DESCRIPTION
- add time-limited trajectory planner endpoints
- fix a bug where endpoints of type void would send a can frame
- improve naming of some functions
- add time-limited trajectory planner tests
- better reporting of incompatible protocol versions