### PR TITLE
Make the scheduler state volatile

### DIFF
--- a/firmware/src/scheduler/scheduler.c
+++ b/firmware/src/scheduler/scheduler.c
@@ -31,7 +31,7 @@
 
 volatile uint32_t msTicks = 0;
 
-SchedulerState state = {0};
+static volatile SchedulerState state = {0};
 
 void WaitForControlLoopInterrupt(void)
 {


### PR DESCRIPTION
- The state variable is altered in the interrupts, thus should be marked volatile.
- Without it, compiler optimisations could have unexpected effects
- This was the cause of https://github.com/tinymovr/Tinymovr/issues/216
- I made it static too as it is only part of scheduler.c