### PR TITLE
Update copyright to MotionLayer P.C. following IP transfer

### DIFF
--- a/docs/LICENSE.txt
+++ b/docs/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2022 Ioannis Chatzikonstantinou (Tinymovr)
+Copyright 2022-2026 MotionLayer P.C.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,8 +20,8 @@ master_doc = 'index'
 # -- Project information -----------------------------------------------------
 
 project = 'Tinymovr'
-copyright = '2020-2024, Yannis Chatzikonstantinou'
-author = 'Yannis Chatzikonstantinou'
+copyright = '2020-2026, MotionLayer P.C.'
+author = 'MotionLayer P.C.'
 
 
 # -- General configuration ---------------------------------------------------

--- a/firmware/LICENSE.txt
+++ b/firmware/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2022 Ioannis Chatzikonstantinou (Tinymovr)
+Copyright 2022-2026 MotionLayer P.C.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/firmware/src/adc/adc.c
+++ b/firmware/src/adc/adc.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/adc/adc.h
+++ b/firmware/src/adc/adc.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/can/can.c
+++ b/firmware/src/can/can.c
@@ -1,6 +1,6 @@
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/can/can.h
+++ b/firmware/src/can/can.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/can/can_func.c
+++ b/firmware/src/can/can_func.c
@@ -26,7 +26,7 @@ uint32_t can_frame_hash;
 
 //  * The function "can_io_config" is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2022 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2022-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/can/can_func.h
+++ b/firmware/src/can/can_func.h
@@ -122,7 +122,7 @@ static inline void can_process_standard(void)
 
 //  * The function "can_process_extended" is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2022 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2022-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by
@@ -198,7 +198,7 @@ static inline void can_transmit_standard(uint8_t dataLen, uint16_t id, const uin
 
 //  * The function "can_transmit_extended" is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2022 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2022-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/common.h
+++ b/firmware/src/common.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/controller/controller.c
+++ b/firmware/src/controller/controller.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/controller/controller.h
+++ b/firmware/src/controller/controller.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/controller/homing_planner.h
+++ b/firmware/src/controller/homing_planner.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/controller/trajectory_planner.c
+++ b/firmware/src/controller/trajectory_planner.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/controller/trajectory_planner.h
+++ b/firmware/src/controller/trajectory_planner.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/gatedriver/gatedriver.c
+++ b/firmware/src/gatedriver/gatedriver.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/gatedriver/gatedriver.h
+++ b/firmware/src/gatedriver/gatedriver.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/main.c
+++ b/firmware/src/main.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/motor/motor.c
+++ b/firmware/src/motor/motor.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/motor/motor.h
+++ b/firmware/src/motor/motor.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/nvm/nvm.c
+++ b/firmware/src/nvm/nvm.c
@@ -1,6 +1,6 @@
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/nvm/nvm.h
+++ b/firmware/src/nvm/nvm.h
@@ -1,6 +1,6 @@
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/observer/observer.c
+++ b/firmware/src/observer/observer.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/observer/observer.h
+++ b/firmware/src/observer/observer.h
@@ -1,7 +1,7 @@
 /* 
  * This file is part of the Tinymovr-Firmware distribution
  * (https://github.com/yconst/tinymovr-firmware).
- * Copyright (c) 2020 Ioannis Chatzikonstantinou.
+ * Copyright (c) 2020-2026 MotionLayer P.C.
  * 
  * This program is free software: you can redistribute it and/or modify  
  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/scheduler/scheduler.c
+++ b/firmware/src/scheduler/scheduler.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/scheduler/scheduler.h
+++ b/firmware/src/scheduler/scheduler.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/sensor/amt22.c
+++ b/firmware/src/sensor/amt22.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/sensor/amt22.h
+++ b/firmware/src/sensor/amt22.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/sensor/as5047.c
+++ b/firmware/src/sensor/as5047.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/sensor/as5047.h
+++ b/firmware/src/sensor/as5047.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/sensor/hall.c
+++ b/firmware/src/sensor/hall.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/sensor/hall.h
+++ b/firmware/src/sensor/hall.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/sensor/ma7xx.c
+++ b/firmware/src/sensor/ma7xx.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/sensor/ma7xx.h
+++ b/firmware/src/sensor/ma7xx.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/sensor/sensor.c
+++ b/firmware/src/sensor/sensor.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/sensor/sensor.h
+++ b/firmware/src/sensor/sensor.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/sensor/sensors.c
+++ b/firmware/src/sensor/sensors.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/sensor/sensors.h
+++ b/firmware/src/sensor/sensors.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/system/system.c
+++ b/firmware/src/system/system.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/system/system.h
+++ b/firmware/src/system/system.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/timer/timer.c
+++ b/firmware/src/timer/timer.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/timer/timer.h
+++ b/firmware/src/timer/timer.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/uart/uart_interface.c
+++ b/firmware/src/uart/uart_interface.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Tinymovr-Firmware distribution
  * (https://github.com/yconst/tinymovr-firmware).
- * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+ * Copyright (c) 2020-2026 MotionLayer P.C.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/uart/uart_interface.h
+++ b/firmware/src/uart/uart_interface.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/uart/uart_lowlevel.c
+++ b/firmware/src/uart/uart_lowlevel.c
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/uart/uart_lowlevel.h
+++ b/firmware/src/uart/uart_lowlevel.h
@@ -1,7 +1,7 @@
 
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by

--- a/firmware/src/utils/utils.h
+++ b/firmware/src/utils/utils.h
@@ -4,7 +4,7 @@
 //  * 
 //  *  *except* for the function "SVM()", which is Copyright (c) 2016-2018 Oskar Weigl
 //  * 
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/watchdog/watchdog.c
+++ b/firmware/src/watchdog/watchdog.c
@@ -3,7 +3,7 @@
 //  * (https://github.com/yconst/tinymovr-firmware).
 //  * 
 //  * Copyright (c) 2022 Eugene Frizza
-//  * Copyright (c) 2022 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2022-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/watchdog/watchdog.h
+++ b/firmware/src/watchdog/watchdog.h
@@ -3,7 +3,7 @@
 //  * (https://github.com/yconst/tinymovr-firmware).
 //  * 
 //  * Copyright (c) 2022 Eugene Frizza
-//  * Copyright (c) 2022 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2022-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/firmware/src/xfs.h
+++ b/firmware/src/xfs.h
@@ -1,6 +1,6 @@
 //  * This file is part of the Tinymovr-Firmware distribution
 //  * (https://github.com/yconst/tinymovr-firmware).
-//  * Copyright (c) 2020-2023 Ioannis Chatzikonstantinou.
+//  * Copyright (c) 2020-2026 MotionLayer P.C.
 //  * 
 //  * This program is free software: you can redistribute it and/or modify  
 //  * it under the terms of the GNU General Public License as published by  

--- a/hardware/LICENSE
+++ b/hardware/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2022 Ioannis Chatzikonstantinou (Tinymovr)
+Copyright 2022-2026 MotionLayer P.C.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/studio/Python/setup.py
+++ b/studio/Python/setup.py
@@ -1,6 +1,6 @@
 """
 Tinymovr Setup Module
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Standard Python module for setting up the Tinymovr package
 
@@ -27,7 +27,7 @@ README = (HERE / "README.md").read_text()
 setup(
     name="tinymovr",
     # version="", #version will be taken from git tag
-    author="Yannis Chatzikonstantinou",
+    author="MotionLayer P.C.",
     author_email="info@tinymovr.com",
     description="Tinymovr Studio",
     long_description=README,

--- a/studio/Python/tests/test_amt22.py
+++ b/studio/Python/tests/test_amt22.py
@@ -1,6 +1,6 @@
 """
 Tinymovr Board Config Tests
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Tests saving and loading Tinymovr configuration to/from NVRAM.
 

--- a/studio/Python/tests/test_as5047.py
+++ b/studio/Python/tests/test_as5047.py
@@ -1,6 +1,6 @@
 """
 Tinymovr Board Config Tests
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Tests saving and loading Tinymovr configuration to/from NVRAM.
 

--- a/studio/Python/tests/test_board.py
+++ b/studio/Python/tests/test_board.py
@@ -1,6 +1,6 @@
 """
 Tinymovr Basic Board Tests
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Tests basic functionality of Tinymovr boards.
 

--- a/studio/Python/tests/test_dfu.py
+++ b/studio/Python/tests/test_dfu.py
@@ -1,6 +1,6 @@
 """
 Tinymovr DFU Test Class
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Implements convenience functionality.
 

--- a/studio/Python/tests/test_export_import.py
+++ b/studio/Python/tests/test_export_import.py
@@ -1,6 +1,6 @@
 """
 Tinymovr Export/Import Tests
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Tests for export/import functionality:
 - YAML spec consistency (all settable config attrs have export: True)

--- a/studio/Python/tests/test_hall.py
+++ b/studio/Python/tests/test_hall.py
@@ -1,6 +1,6 @@
 """
 Tinymovr Board Config Tests
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Tests saving and loading Tinymovr configuration to/from NVRAM.
 

--- a/studio/Python/tests/test_nvm.py
+++ b/studio/Python/tests/test_nvm.py
@@ -1,6 +1,6 @@
 """
 Tinymovr Board Config Tests
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Tests saving and loading Tinymovr configuration to/from NVRAM.
 

--- a/studio/Python/tests/test_rates.py
+++ b/studio/Python/tests/test_rates.py
@@ -1,6 +1,6 @@
 """
 Tinymovr Message Rate Tests
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Tests the rate of CAN messages on the bus.
 

--- a/studio/Python/tests/test_simulation.py
+++ b/studio/Python/tests/test_simulation.py
@@ -1,6 +1,6 @@
 """
 Tinymovr Simulation Tests
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Tests functionality of the Tinymovr Studio using a simulated Tinymovr device.
 

--- a/studio/Python/tests/test_traj_planner.py
+++ b/studio/Python/tests/test_traj_planner.py
@@ -1,6 +1,6 @@
 """
 Tinymovr Trajectory Planner Tests
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Tests the functionality of the Tinymovr trajectory planner.
 

--- a/studio/Python/tests/tm_test_case.py
+++ b/studio/Python/tests/tm_test_case.py
@@ -1,6 +1,6 @@
 """
 Tinymovr Base Test Class
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Implements convenience functionality.
 

--- a/studio/Python/tinymovr/bus_manager.py
+++ b/studio/Python/tinymovr/bus_manager.py
@@ -1,6 +1,6 @@
 """
 Tinymovr BusManager Module
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Implements a BusRouter class to distribute incoming traffic according to rules
 

--- a/studio/Python/tinymovr/bus_router.py
+++ b/studio/Python/tinymovr/bus_router.py
@@ -1,6 +1,6 @@
 """
 Tinymovr BusRouter Module
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Implements a BusRouter class to distribute incoming traffic according to rules
 

--- a/studio/Python/tinymovr/channel.py
+++ b/studio/Python/tinymovr/channel.py
@@ -1,6 +1,6 @@
 """
 Tinymovr CAN Channel Module
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Implements a CAN bus communications channel
 

--- a/studio/Python/tinymovr/cli.py
+++ b/studio/Python/tinymovr/cli.py
@@ -26,7 +26,7 @@ from tinymovr.config import get_bus_config, configure_logging, add_spec
 
 """
 Tinymovr CLI Module
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 The Tinymovr Studio IPython-based command line interface
 

--- a/studio/Python/tinymovr/codec/codec.py
+++ b/studio/Python/tinymovr/codec/codec.py
@@ -1,6 +1,6 @@
 """
 Tinymovr Codecs Module
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Implements codecs for various datatypes.
 

--- a/studio/Python/tinymovr/config/config.py
+++ b/studio/Python/tinymovr/config/config.py
@@ -1,6 +1,6 @@
 """
 Tinymovr Configuration Module
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Implements functions to configure various aspects of Studio.
 

--- a/studio/Python/tinymovr/constants.py
+++ b/studio/Python/tinymovr/constants.py
@@ -1,6 +1,6 @@
 """
 Tinymovr Constants
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Defines various constants used throughout Tinymovr Studio
 

--- a/studio/Python/tinymovr/device_discovery.py
+++ b/studio/Python/tinymovr/device_discovery.py
@@ -1,6 +1,6 @@
 """
 Tinymovr DeviceDiscovery Module
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Implements a class to discover nodes on the CAN bus based on
 the reception of heartbeat frames

--- a/studio/Python/tinymovr/dfu.py
+++ b/studio/Python/tinymovr/dfu.py
@@ -30,7 +30,7 @@ from tinymovr.channel import ResponseError
 
 """
 Tinymovr DFU Module
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 The Tinymovr Studio IPython-based command line interface
 

--- a/studio/Python/tinymovr/gui/gui.py
+++ b/studio/Python/tinymovr/gui/gui.py
@@ -25,7 +25,7 @@ from tinymovr.config import configure_logging, add_spec
 
 """
 Tinymovr Studio GUI
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 The graphical user interface of Tinymovr Studio
 

--- a/studio/Python/tinymovr/gui/helpers.py
+++ b/studio/Python/tinymovr/gui/helpers.py
@@ -1,6 +1,6 @@
 """
 Tinymovr GUI Helpers
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Various GUI helper functions
 

--- a/studio/Python/tinymovr/gui/widgets.py
+++ b/studio/Python/tinymovr/gui/widgets.py
@@ -1,6 +1,6 @@
 """
 Tinymovr Studio custom Qt widgets
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 Various customized widgets for the Tinymovr Studio app
 

--- a/studio/Python/tinymovr/gui/window.py
+++ b/studio/Python/tinymovr/gui/window.py
@@ -1,6 +1,6 @@
 """
 Tinymovr GUI Window
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 The GUI Window class that subclasses QMainWindow
 

--- a/studio/Python/tinymovr/gui/worker.py
+++ b/studio/Python/tinymovr/gui/worker.py
@@ -1,6 +1,6 @@
 """
 Tinymovr GUI Worker
-Copyright Ioannis Chatzikonstantinou 2020-2023
+Copyright 2020-2026 MotionLayer P.C.
 
 The GUI Worker class, subclass of QObject, that handles
 updates and IO, running in a separate thread


### PR DESCRIPTION
## Summary

- Updates all copyright and author attributions from Ioannis (Yannis) Chatzikonstantinou to MotionLayer P.C., reflecting the IP transfer effective March 31, 2026.
- 78 files changed across firmware source headers, Python source headers, license files, documentation config, and setup.py.
- Third-party copyrights (ARM CMSIS, Qorvo, SEGGER RTT, Oskar Weigl, Eugene Frizza) are left unchanged.
- Build artifacts under `studio/Python/build/lib/` are not modified (will regenerate on next build).

## Test plan

- [ ] Verify `firmware/LICENSE.txt`, `docs/LICENSE.txt`, `hardware/LICENSE` show "Copyright 2022-2026 MotionLayer P.C."
- [ ] Verify `docs/conf.py` shows updated copyright and author
- [ ] Verify `studio/Python/setup.py` shows updated copyright header and author field
- [ ] Grep for "Ioannis" and "Yannis" to confirm no project-owned source files were missed
- [ ] Confirm third-party copyright lines are untouched (e.g., Oskar Weigl in `utils.h`, Eugene Frizza in `watchdog.c/h`)
- [ ] Firmware builds without warnings (`make release REV=R52`)

<!-- PRELOOP_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Attribution-only header and license updates; no functional or behavioral changes detected.
>
> **Overview**
> This PR updates copyright and author attribution across firmware, docs, and Python sources to MotionLayer P.C. following the IP transfer. No code logic changes are included, and the updates preserve existing third-party attribution lines.
>
> <sup>Written by [Preloop PR Reviewer](https://preloop.ai) for commit 200fa5a. Updates automatically on new commits.</sup>
<!-- /PRELOOP_SUMMARY -->