### PR TITLE
Add v3.0.0 source-moved-private notice to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@
 > **no longer updated**. To use the latest firmware or Studio, download the
 > latest release artifacts.
 >
+> ### License
+>
+> The source in this repository reflects the state at v3.0.0 and remains
+> available under its original per-directory licenses:
+>
+> - **Firmware** (`firmware/`) — MIT
+> - **Hardware** (`hardware/`) — MIT
+> - **Documentation** (`docs/`) — MIT
+> - **Studio Python** and the overall project — GPLv3
+>   (see root `LICENSE.txt` and `studio/LICENSE`)
+>
+> Those terms remain in effect for the code as of v3.0.0. Releases from
+> v3.1 onward are distributed by MotionLayer P.C. as proprietary binaries
+> built from a private codebase; their source is not published.
+>
 > For support: [Discord](https://discord.gg/vNvmpfthug) ·
 > [Discussions](https://github.com/motionlayer/Tinymovr/discussions) ·
 > [Issues](https://github.com/motionlayer/Tinymovr/issues) ·

--- a/README.md
+++ b/README.md
@@ -1,7 +1,28 @@
+> ## Notice — Source moved private as of v3.0.0
+>
+> Active source development for Tinymovr has moved to a **private repository**
+> as of v3.0.0. This public repository continues to host:
+>
+> - **Documentation** in [`docs/`](docs/), built and published at
+>   <https://tinymovr.readthedocs.io>.
+> - **Releases** with attached binaries (firmware, Python wheel, Studio Web)
+>   on the [Releases page](https://github.com/motionlayer/Tinymovr/releases).
+>
+> The source code in this repository reflects the state at v3.0.0 and is
+> **no longer updated**. To use the latest firmware or Studio, download the
+> latest release artifacts.
+>
+> For support: [Discord](https://discord.gg/vNvmpfthug) ·
+> [Discussions](https://github.com/motionlayer/Tinymovr/discussions) ·
+> [Issues](https://github.com/motionlayer/Tinymovr/issues) ·
+> [tinymovr.com](https://tinymovr.com)
+
+---
+
 ![FW Check Build](https://github.com/yconst/tinymovr/workflows/Tinymovr%20Firmware%20Check%2FBuild/badge.svg)
 ![Studio Lint Test](https://github.com/yconst/tinymovr/workflows/Tinymovr%20Studio%20Lint%2FTest/badge.svg)
 ![Docs Build](https://github.com/yconst/tinymovr/workflows/Tinymovr%20Docs%20Build/badge.svg)
-[![Discord](https://img.shields.io/discord/742400176664084535)](https://discord.gg/UnmfuVzKuQ)
+[![Discord](https://img.shields.io/discord/742400176664084535)](https://discord.gg/vNvmpfthug)
 
 [Tinymovr is an affordable motor controller](https://tinymovr.com) with integrated encoder and CAN bus for precise control of 3-phase brushless motors (PMSMs). 
 

--- a/studio/Python/README.md
+++ b/studio/Python/README.md
@@ -1,3 +1,17 @@
+> ## Notice — Source moved private as of v3.0.0
+>
+> The Python source in this directory reflects the state at v3.0.0 and
+> is **no longer updated**. Install the latest version (now branded as
+> Motionlayer Studio Desktop) from PyPI:
+>
+> ```bash
+> pip install -U tinymovr
+> ```
+>
+> Documentation: <https://tinymovr.readthedocs.io>
+
+---
+
 ![Studio Lint Test](https://github.com/yconst/tinymovr/workflows/Tinymovr%20Studio%20Lint%2FTest/badge.svg)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 


### PR DESCRIPTION
## Summary

Adds a clear notice to the top of the top-level [`README.md`](../blob/notice/source-private/README.md) and [`studio/Python/README.md`](../blob/notice/source-private/studio/Python/README.md) informing users that active source development has moved to a private repository as of v3.0.0.

The notice clarifies that:
- Documentation in `docs/` continues to be maintained here.
- Releases (firmware, Python wheel, Studio Web) continue to be published here.
- The source in this repo reflects the v3.0.0 state and is no longer updated.

Also fixes the Discord badge URL in the top-level README to use the current invite (\`vNvmpfthug\`).

 No changes to source code, license, or any other docs.
